### PR TITLE
Fixing tests on .NET 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Cadenza-Tests.VisualState.xml
 TestResult.xml
 *.pidb
 *.exe.mdb
+_ReSharper.*
+*.user
+*.cache

--- a/src/Cadenza.Core/Cadenza.Core.csproj
+++ b/src/Cadenza.Core/Cadenza.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,6 +10,7 @@
     <RootNamespace>Cadenza</RootNamespace>
     <AssemblyName>Cadenza.Core</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cadenza.Core/Documentation/en/index.xml
+++ b/src/Cadenza.Core/Documentation/en/index.xml
@@ -3,6 +3,9 @@
     <Assembly Name="Cadenza.Core" Version="0.1.0.0">
       <Attributes>
         <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.Default | System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints | System.Diagnostics.DebuggableAttribute+DebuggingModes.EnableEditAndContinue)</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>System.Reflection.AssemblyCompany("")</AttributeName>
         </Attribute>
         <Attribute>
@@ -22,6 +25,9 @@
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyTrademark("")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.CompilationRelaxations(8)</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>

--- a/src/Cadenza.Core/Test/Cadenza.Core-Tests.csproj
+++ b/src/Cadenza.Core/Test/Cadenza.Core-Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,6 +10,7 @@
     <RootNamespace>Cadenza</RootNamespace>
     <AssemblyName>Cadenza.Core-Tests</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cadenza/Cadenza.Collections/EnumerableCoda.cs
+++ b/src/Cadenza/Cadenza.Collections/EnumerableCoda.cs
@@ -836,10 +836,16 @@ namespace Cadenza.Collections {
 			List<List<TSource>> r = new List<List<TSource>> ();
 			foreach (IEnumerable<TSource> row in self) {
 				List<TSource> items = new List<TSource> ();
-				r.Add (items);
-				foreach (TSource item in row) {
-					items.Add (item);
-				}
+                if (row == null)
+                    r.Add(null);
+			    else
+                {
+                    r.Add(items);                    
+                    foreach (TSource item in row)
+                    {
+                        items.Add(item);
+                    }
+                }
 			}
 			return r;
 		}

--- a/src/Cadenza/Documentation/en/Cadenza.Collections/EnumerableCoda.xml
+++ b/src/Cadenza/Documentation/en/Cadenza.Collections/EnumerableCoda.xml
@@ -4384,6 +4384,7 @@ Assert.IsTrue (
           <code lang="C#" src="../../Test/Cadenza.Collections/EnumerableCodaTest.cs#ToList">int[][] a = new int[][]{
 	new int[]{1, 2, 3},
 	new int[]{4, 5, 6},
+             null
 };
 IEnumerable&lt;IEnumerable&lt;int&gt;&gt; b = a;
 List&lt;List&lt;int&gt;&gt; c = b.ToList ();
@@ -4396,6 +4397,8 @@ Assert.AreEqual (a [0][2], c [0][2]);
 Assert.AreEqual (a [1][0], c [1][0]);
 Assert.AreEqual (a [1][1], c [1][1]);
 Assert.AreEqual (a [1][2], c [1][2]);
+   Assert.AreEqual (a [2],    c [2]);
+
 </code>
         </remarks>
         <exception cref="T:System.ArgumentNullException">

--- a/src/Cadenza/Documentation/en/index.xml
+++ b/src/Cadenza/Documentation/en/index.xml
@@ -6,6 +6,9 @@
           <AttributeName>System.CLSCompliant(true)</AttributeName>
         </Attribute>
         <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.Default | System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints | System.Diagnostics.DebuggableAttribute+DebuggingModes.EnableEditAndContinue)</AttributeName>
+        </Attribute>
+        <Attribute>
           <AttributeName>System.Reflection.AssemblyCompany("Novell, Inc.")</AttributeName>
         </Attribute>
         <Attribute>
@@ -28,6 +31,9 @@
         </Attribute>
         <Attribute>
           <AttributeName>System.Reflection.AssemblyTrademark("")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.CompilationRelaxations(8)</AttributeName>
         </Attribute>
         <Attribute>
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
@@ -8494,7 +8500,7 @@
     </ExtensionMethod>
     <ExtensionMethod>
       <Targets>
-        <Target Type="T:TSource[,]" />
+        <Target Type="T:TSource[0:,0:]" />
       </Targets>
       <Member MemberName="Rows&lt;TSource&gt;">
         <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.IEnumerable&lt;TSource&gt;&gt; Rows&lt;TSource&gt; (this TSource[,] self);" />
@@ -8521,7 +8527,7 @@
           <see cref="T:System.Collections.Generic.IEnumerable{System.Collections.Generic.IEnumerable{TSource}}" />.
         </summary>
         </Docs>
-        <Link Type="Cadenza.RectangularArrayCoda" Member="M:Cadenza.RectangularArrayCoda.Rows``1(``0[,])" />
+        <Link Type="Cadenza.RectangularArrayCoda" Member="M:Cadenza.RectangularArrayCoda.Rows``1(``0[0:,0:])" />
       </Member>
     </ExtensionMethod>
     <ExtensionMethod>

--- a/src/Cadenza/Test/Cadenza-Tests.csproj
+++ b/src/Cadenza/Test/Cadenza-Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +12,7 @@
     <AssemblyName>Cadenza-Tests</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -19,6 +20,7 @@
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">NET_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -28,6 +30,7 @@
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">NET_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/src/Cadenza/Test/Cadenza.Collections/EnumerableCodaTest.cs
+++ b/src/Cadenza/Test/Cadenza.Collections/EnumerableCodaTest.cs
@@ -1485,6 +1485,7 @@ namespace Cadenza.Collections.Tests {
 			int[][] a = new int[][]{
 				new int[]{1, 2, 3},
 				new int[]{4, 5, 6},
+                null
 			};
 			IEnumerable<IEnumerable<int>> b = a;
 			List<List<int>> c = b.ToList ();
@@ -1497,7 +1498,9 @@ namespace Cadenza.Collections.Tests {
 			Assert.AreEqual (a [1][0], c [1][0]);
 			Assert.AreEqual (a [1][1], c [1][1]);
 			Assert.AreEqual (a [1][2], c [1][2]);
-			#endregion
+		    Assert.AreEqual (a [2],    c [2]);
+
+		    #endregion
 		}
 
 		[Test, ExpectedException (typeof (ArgumentNullException))]


### PR DESCRIPTION
ToList<TSource> (this IEnumerable<IEnumerable<TSource>> self) did not handle null entries.

This didn't show up in 3.5 because (I think) the wrong ToList() was being called.

We also needed to detect framework version 4.0 on .NET and set the same flag as is set by Mono.
